### PR TITLE
docker.md "mount the following volumes" section uses same paths as script

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -39,8 +39,8 @@ Simple symlinking to another path on the host system may not work, since there w
 ## Container Setup
 
 Mount the following volumes:
-- Media folder `/media`
-- Profile folder containing UMS.conf `/profile`
+- Media folder `/root/media`
+- Profile folder containing UMS.conf `/root/.config/UMS`
 
 Expose/forward these ports from the host: 1044, 5001, 9001.
 


### PR DESCRIPTION
If the paths are copied from this section instead of the script (I did this the first time), the incorrect mountpoints will be used.

Cheers :hugs: 